### PR TITLE
implementation of Chromium style encoding/decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ManualTests/
 build/
 .git/
+.vscode/**

--- a/MTBase64/Implementations/default.cpp
+++ b/MTBase64/Implementations/default.cpp
@@ -68,7 +68,7 @@ struct MTBase64::IndexTableAccessor {
             MTBase64::ErrorCodeTable::kIllegalFunctionCall,
             "input buffer length is 0.");
 
-        uint8_t padding_byte    = table.GetPadding(),  remainder    = src_len % 3;
+        uint8_t padding_byte    = table.GetPadding(),   remainder   = src_len % 3;
         size_t d_bc             = 0,                    e_bc        = 0;
 
 
@@ -93,8 +93,11 @@ struct MTBase64::IndexTableAccessor {
 
             dest[e_bc++] = table.e0.at(db1);
             dest[e_bc++] = table.e1.at((db1 & 0x03) << 4);
-            dest[e_bc++] = padding_byte;
-            dest[e_bc++] = padding_byte;
+
+            if (padding) {
+                dest[e_bc++] = padding_byte;
+                dest[e_bc++] = padding_byte;
+            }
             break;
         case 2:
             db1 = src[d_bc++];
@@ -103,7 +106,10 @@ struct MTBase64::IndexTableAccessor {
             dest[e_bc++] = table.e0.at(db1);
             dest[e_bc++] = table.e1.at(((db1 & 0x03) << 4) | ((db2 >> 4) & 0x0F));
             dest[e_bc++] = table.e2.at((db2 & 0x0F) << 2);
-            dest[e_bc++] = padding_byte;
+            
+            if (padding) {
+                dest[e_bc++] = padding_byte;
+            }
             break;
         default:
             break;

--- a/MTBase64/Implementations/default.cpp
+++ b/MTBase64/Implementations/default.cpp
@@ -1,0 +1,112 @@
+#include "MTBase64.hpp"
+
+
+struct MTBase64::IndexTableAccessor {
+    /*Reverse chunking of four 6 bit bytes to three 8 bit bytes by using reverse
+    lookup table and padding checking*/
+    static void DecodeBase64(uint8_t *dest, const uint8_t *src, std::size_t src_len,
+                             const MTBase64::IndexTable& table,
+                             bool padding = true) {
+
+        if (padding && !MTBase64::ValidPaddedEncodedLength(src_len))
+            throw MTBase64::MTBase64Exception(
+            __FILE__, __FUNCTION__, __LINE__,
+            MTBase64::ErrorCodeTable::kNotValidBase64,
+            "Not valid base64 encoding length when padding is being used.");
+
+        if (!padding && !MTBase64::ValidUnpaddedEncodedLength(src_len))
+            throw MTBase64::MTBase64Exception(
+            __FILE__, __FUNCTION__, __LINE__,
+            MTBase64::ErrorCodeTable::kNotValidBase64,
+            "Not valid base64 encoding length when padding is not being used.");
+
+        uint8_t padding_byte = table.GetPadding();
+        for (size_t e_bc = 0, d_bc = 0; e_bc < src_len;) {
+
+            /*Padding is being used as end of data identifier even when
+            `padding = false`*/
+            uint8_t eb1 = src[e_bc++];
+            uint8_t eb2 = src[e_bc++];
+            uint8_t eb3 = (e_bc == src_len) ? padding_byte : src[e_bc++];
+            uint8_t eb4 = (e_bc == src_len) ? padding_byte : src[e_bc++];
+
+            /*Low level stuff */
+            uint8_t to_add = 3 - (eb4 == padding_byte) - (eb3 == padding_byte);
+            /*First use of [[fallthrough]]*/
+            switch (to_add) {
+            case 3:
+                dest[d_bc + 2] = (
+                (table.ReverseLookup(eb3) << 6) | table.ReverseLookup(eb4)
+                );
+                [[fallthrough]];
+            case 2:
+                dest[d_bc + 1] = (
+                (table.ReverseLookup(eb2) << 4) | (table.ReverseLookup(eb3) >> 2)
+                );
+                [[fallthrough]];
+            case 1:
+                dest[d_bc + 0] = (
+                (table.ReverseLookup(eb1) << 2) | (table.ReverseLookup(eb2) >> 4)
+                );
+                [[fallthrough]];
+            default:
+                d_bc += to_add;
+                break;
+            }
+        }
+    }
+
+    /*Splits the encoding process into the encoding of whole 3-byte chunks and the
+    encoding of the last 1-2 byte chunk with padding at the end if used*/
+    static void EncodeBase64(uint8_t *dest, const uint8_t *src, std::size_t src_len,
+                             const MTBase64::IndexTable& table,
+                             bool padding = true) {
+
+        if(src_len == 0)
+            throw MTBase64::MTBase64Exception(
+            __FILE__, __FUNCTION__, __LINE__,
+            MTBase64::ErrorCodeTable::kIllegalFunctionCall,
+            "input buffer length is 0.");
+
+        uint8_t padding_byte    = table.GetPadding(),  remainder    = src_len % 3;
+        size_t d_bc             = 0,                    e_bc        = 0;
+
+
+        uint8_t db1, db2, db3;
+        /*The loop bellow encodes only whole chunks of 3 bytes*/
+        while (d_bc < src_len - remainder) {
+            db1 = src[d_bc++];
+            db2 = src[d_bc++];
+            db3 = src[d_bc++];
+
+            dest[e_bc++] = table.e0.at(db1);
+            dest[e_bc++] = table.e1.at(((db1 & 0x03) << 4) | ((db2 >> 4) & 0x0F));
+            dest[e_bc++] = table.e1.at(((db2 & 0x0F) << 2) | ((db3 >> 6) & 0x03));
+            dest[e_bc++] = table.e2.at(db3);
+        }
+
+        switch (remainder) {
+        case 0:
+            break;
+        case 1:
+            db1 = src[d_bc++];
+
+            dest[e_bc++] = table.e0.at(db1);
+            dest[e_bc++] = table.e1.at((db1 & 0x03) << 4);
+            dest[e_bc++] = padding_byte;
+            dest[e_bc++] = padding_byte;
+            break;
+        case 2:
+            db1 = src[d_bc++];
+            db2 = src[d_bc++];
+
+            dest[e_bc++] = table.e0.at(db1);
+            dest[e_bc++] = table.e1.at(((db1 & 0x03) << 4) | ((db2 >> 4) & 0x0F));
+            dest[e_bc++] = table.e2.at((db2 & 0x0F) << 2);
+            dest[e_bc++] = padding_byte;
+            break;
+        default:
+            break;
+        }
+    }
+};

--- a/MTBase64/MTBase64.cpp
+++ b/MTBase64/MTBase64.cpp
@@ -115,7 +115,6 @@ std::size_t MTBase64::GetEncodedLength(std::size_t decoded_length,
 }
 
 
-
 MTBase64::IndexTable::IndexTable(const std::array<uint8_t, 64>&  linear_table,
                                  uint8_t padding) : e(linear_table),
                                  padding_(padding) {

--- a/MTBase64/MTBase64.hpp
+++ b/MTBase64/MTBase64.hpp
@@ -20,6 +20,8 @@
 	#error "Not implemented for big endian platforms!"
 #endif
 
+#define MTBASE64__BADCHAR 0x01FFFFFF
+
 namespace MTBase64 {
 
 enum class ErrorCodeTable
@@ -52,8 +54,18 @@ public:
 class IndexTable
 {
 private:
-  std::array<uint8_t, 64> table_;
-  std::array<int16_t, 256> rw_table_;
+  std::array<uint32_t, 256> d0;
+  std::array<uint32_t, 256> d1;
+  std::array<uint32_t, 256> d2;
+  std::array<uint32_t, 256> d3;
+
+  std::array<uint32_t, 256> e0;
+  std::array<uint32_t, 256> e1;
+  std::array<uint32_t, 256> e2;
+  
+
+  std::array<uint8_t, 64> e;
+  std::array<uint8_t, 256> d;
 
   uint8_t padding_;
 
@@ -65,7 +77,11 @@ public:
   uint8_t ReverseLookup(uint8_t index) const;
 
   uint8_t GetPadding() const;
+
+  friend struct IndexTableAccessor;
 };
+
+struct IndexTableAccessor;
 
 extern const IndexTable kDefaultBase64;
 extern const IndexTable kUrlSafeBase64;
@@ -75,24 +91,24 @@ uint8_t GetPaddingNum(const C& data, const IndexTable& table);
 
 template <template <typename> class Container, typename T>
 Container<T> EncodeCTR(const Container<T>& input, const IndexTable& table,
-                       bool using_padding = true);
+                       bool padding = true);
 
 template <template <typename> class Container, typename T>
 Container<T> DecodeCTR(const Container<T>& input, const IndexTable& table,
-                       bool using_padding = true);
+                       bool padding = true);
 
 
 bool ValidPaddedEncodedLength(std::size_t encoded_length);
 bool ValidUnpaddedEncodedLength(std::size_t encoded_length);
 
-std::size_t GetEncodedLength(std::size_t decoded_length, bool using_padding);
-std::size_t GetDecodedLength(std::size_t encoded_length, bool using_padding,
+std::size_t GetEncodedLength(std::size_t decoded_length, bool padding);
+std::size_t GetDecodedLength(std::size_t encoded_length, bool padding,
                              uint8_t padding_num = 0);
 
 void EncodeMem(uint8_t *dest, const uint8_t *src, std::size_t src_len,
-               const IndexTable& table, bool using_padding = true);
+               const IndexTable& table, bool padding = true);
 void DecodeMem(uint8_t *dest, const uint8_t *src, std::size_t src_len,
-               const IndexTable& table, bool using_padding = true);
+               const IndexTable& table, bool padding = true);
 
 } /* MTBase64 */
 /*Import the template implementation file*/

--- a/MTBase64/MTBase64.tcc
+++ b/MTBase64/MTBase64.tcc
@@ -24,6 +24,7 @@ namespace MTBase64 {
                         bool padding) {
     size_t encoded_length = MTBase64::GetEncodedLength(input.size(),
                                                        padding);
+    /* Trying to follow the strict aliansing rules of C++ using aligned malloc */
     std::shared_ptr<uint8_t> encoded_buffer(static_cast<uint8_t*>(
                                               std::aligned_alloc(
                                                 alignof(T),
@@ -56,6 +57,7 @@ namespace MTBase64 {
     uint8_t padding_num = GetPaddingNum(input, table);
     std::size_t decoded_length = GetDecodedLength(input.size(), padding,
                                              padding_num);
+    /* Trying to follow the strict aliansing rules of C++ using aligned malloc */
     std::shared_ptr<uint8_t> decoded_buffer(static_cast<uint8_t*>(
                                               std::aligned_alloc(
                                                 alignof(T),

--- a/MTBase64/MTBase64.tcc
+++ b/MTBase64/MTBase64.tcc
@@ -24,7 +24,12 @@ namespace MTBase64 {
                         bool padding) {
     size_t encoded_length = MTBase64::GetEncodedLength(input.size(),
                                                        padding);
-    std::shared_ptr<uint8_t> encoded_buffer(new uint8_t[encoded_length],
+    std::shared_ptr<uint8_t> encoded_buffer(static_cast<uint8_t*>(
+                                              std::aligned_alloc(
+                                                alignof(T),
+                                                encoded_length
+                                              )
+                                            ),
                                             std::default_delete<uint8_t[]>());
 
     EncodeMem(

--- a/MTBase64/MTBase64.tcc
+++ b/MTBase64/MTBase64.tcc
@@ -21,16 +21,15 @@ namespace MTBase64 {
 
   template <template <typename> class Container, typename T>
   Container<T> EncodeCTR(const Container<T>& input, const IndexTable& table,
-                        bool using_padding) {
+                        bool padding) {
     size_t encoded_length = MTBase64::GetEncodedLength(input.size(),
-                                                       using_padding);
-
+                                                       padding);
     std::shared_ptr<uint8_t> encoded_buffer(new uint8_t[encoded_length],
                                             std::default_delete<uint8_t[]>());
 
     EncodeMem(
       encoded_buffer.get(), reinterpret_cast<const uint8_t *>(input.data()),
-      input.size(), table, using_padding);
+      input.size(), table, padding);
 
     Container<T> output(reinterpret_cast<T*>(encoded_buffer.get()),
                         reinterpret_cast<T*>(encoded_buffer.get())+encoded_length);
@@ -40,24 +39,24 @@ namespace MTBase64 {
 
   template <template <typename> class Container, typename T>
   Container<T> DecodeCTR(const Container<T>& input, const IndexTable& table,
-                          bool using_padding) {
+                          bool padding) {
 
-    if ((using_padding && ((input.size() % 4) != 0)) ||
-        (!using_padding && ((input.size() % 4) == 1)))
+    if ((padding && ((input.size() % 4) != 0)) ||
+        (!padding && ((input.size() % 4) == 1)))
         throw MTBase64::MTBase64Exception(
           __FILE__, __FUNCTION__, __LINE__,
           MTBase64::ErrorCodeTable::kNotValidBase64,
           "Not valid base64 encoding length");
 
     uint8_t padding_num = GetPaddingNum(input, table);
-    std::size_t decoded_length = GetDecodedLength(input.size(), using_padding,
+    std::size_t decoded_length = GetDecodedLength(input.size(), padding,
                                              padding_num);
     std::shared_ptr<uint8_t> decoded_buffer(new uint8_t[decoded_length],
                                              std::default_delete<uint8_t[]>());
 
     DecodeMem(
       decoded_buffer.get(), reinterpret_cast<const uint8_t *>(input.data()),
-      input.size(), table, using_padding);
+      input.size(), table, padding);
 
     Container<T> output(reinterpret_cast<T*>(decoded_buffer.get()),
                         reinterpret_cast<T*>(decoded_buffer.get())+decoded_length);

--- a/MTBase64/MTBase64.tcc
+++ b/MTBase64/MTBase64.tcc
@@ -56,8 +56,13 @@ namespace MTBase64 {
     uint8_t padding_num = GetPaddingNum(input, table);
     std::size_t decoded_length = GetDecodedLength(input.size(), padding,
                                              padding_num);
-    std::shared_ptr<uint8_t> decoded_buffer(new uint8_t[decoded_length],
-                                             std::default_delete<uint8_t[]>());
+    std::shared_ptr<uint8_t> decoded_buffer(static_cast<uint8_t*>(
+                                              std::aligned_alloc(
+                                                alignof(T),
+                                                decoded_length
+                                              )
+                                            ),
+                                            std::default_delete<uint8_t[]>());
 
     DecodeMem(
       decoded_buffer.get(), reinterpret_cast<const uint8_t *>(input.data()),

--- a/Tests/Test_MTBase64.cpp
+++ b/Tests/Test_MTBase64.cpp
@@ -519,10 +519,8 @@ TEST_CASE("Test MTBase64::DecodeStr", "[MTBase64::DecodeStr]") {
     REQUIRE_THROWS_AS(MTBase64::DecodeCTR(std::string("?"), table, false),
                       MTBase64::MTBase64Exception);
 
-    /*An exception should be raised from ReverseLookup function because of chars
-    not in the currently used index table*/
     REQUIRE_THROWS_AS(MTBase64::DecodeCTR(std::string("\x01\x02\x03\x04"), table,
-                                          false), std::out_of_range);
+                                          false), MTBase64::MTBase64Exception);
   }
 
   SECTION("Test decoding with used padding and std::string container") {
@@ -869,13 +867,14 @@ TEST_CASE("Test MTBase64::DecodeMem", "[MTBase64::DecodeMem]") {
     REQUIRE_THROWS_AS(MTBase64::DecodeMem(nullptr, nullptr, 1, table, false),
                       MTBase64::MTBase64Exception);
 
-    /*std::out_of_range should be raised when using chars in encoded buffer that
-    are not defined in the used index table. Exception is being raised from
-    ReverseLookup member function in IndexTable class*/
+    /* MTBase64::MTBase64Exception should be raised when using chars in encoded buffer
+     * that are not defined in the used index table. Exception is being raised from
+     * ReverseLookup member function in IndexTable class
+     */
     REQUIRE_THROWS_AS(
       MTBase64::DecodeMem(dest.get(),
                           reinterpret_cast<const uint8_t*>("\x00\x00=="), 4,
-                          table, true), std::out_of_range);
+                          table, true), MTBase64::MTBase64Exception);
   }
 
   SECTION("Test decoding with padding") {


### PR DESCRIPTION
Implemented a faster technique to encode and decode base64 using multiple encode and decode tables. This technique is implemented as the standard base64 encoding/decoding technique in Chromium. The source codes for the original Chromium implementations can be seen bellow.

[https://github.com/client9/stringencoders/blob/master/src/modp_b64_gen.c](https://github.com/client9/stringencoders/blob/master/src/modp_b64_gen.c)
[https://github.com/client9/stringencoders/blob/master/src/modp_b64.c](https://github.com/client9/stringencoders/blob/master/src/modp_b64.c)
